### PR TITLE
Update setup.py for PEP 440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.md') as readme_file:
 setup(
        # the name must match the folder name 'verysimplemodule'
         name="drawio_network_plot", 
-        version="0.0.02 Beta",
+        version="0.0.02Beta",
         author="Amr ElHusseiny",
         author_email="amroashram@hotmail.com",
         description=DESCRIPTION,


### PR DESCRIPTION
For versions of setuptools >66 legacy version names are not allowed.  This prevents pip from installing drawio_network_plot.

Permitted characters in PEP 440 are:
- ASCII letters ([a-zA-Z])
- ASCII digits ([0-9])
- periods (.)